### PR TITLE
Make game layout responsive with touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,24 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Badger Bobble</h1>
-    <canvas id="gameCanvas" width="800" height="600"></canvas>
+    <main class="game-shell">
+        <h1>Badger Bobble</h1>
+        <canvas id="gameCanvas" width="800" height="600"></canvas>
+        <div class="controls" aria-label="Touch controls">
+            <div class="control-row utility-controls">
+                <button class="control-button" data-key="Enter" data-discrete="true">Start</button>
+                <button class="control-button" data-key="Escape" data-discrete="true">Pause</button>
+            </div>
+            <div class="control-row movement-controls">
+                <button class="control-button" data-key="ArrowLeft" data-hold="true">◀</button>
+                <button class="control-button" data-key="Space" data-hold="true" data-discrete="true">Jump</button>
+                <button class="control-button" data-key="ArrowRight" data-hold="true">▶</button>
+            </div>
+            <div class="control-row action-controls">
+                <button class="control-button" data-key="KeyZ" data-hold="true">Bubble</button>
+            </div>
+        </div>
+    </main>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -242,6 +242,113 @@ let nextPrizeTimer = 0;
 // Input handling
 let keys = {};
 
+const controlButtons = document.querySelectorAll('.control-button');
+const controlPointerStates = new Map();
+
+controlButtons.forEach((button) => {
+    const key = button.dataset.key;
+    const isHold = button.dataset.hold === 'true';
+    const isDiscrete = button.dataset.discrete === 'true';
+
+    if (!key) {
+        return;
+    }
+
+    if (isHold) {
+        controlPointerStates.set(button, new Set());
+    }
+
+    const pressKey = (event) => {
+        event.preventDefault();
+        primeAudio();
+
+        if (!keys[key]) {
+            handleDiscreteKeyPress(key);
+        } else if (isDiscrete && !isHold) {
+            handleDiscreteKeyPress(key);
+        }
+
+        if (isHold) {
+            const pointerIds = controlPointerStates.get(button);
+            pointerIds.add(event.pointerId);
+            keys[key] = true;
+            button.classList.add('active');
+            if (typeof button.setPointerCapture === 'function') {
+                try {
+                    button.setPointerCapture(event.pointerId);
+                } catch (error) {
+                    // Some browsers may throw if capture is not available.
+                }
+            }
+        } else {
+            keys[key] = true;
+            button.classList.add('active');
+            requestAnimationFrame(() => {
+                keys[key] = false;
+                button.classList.remove('active');
+            });
+        }
+    };
+
+    const releaseKey = (event) => {
+        event.preventDefault();
+        if (!isHold) {
+            return;
+        }
+
+        const pointerIds = controlPointerStates.get(button);
+        if (pointerIds) {
+            pointerIds.delete(event.pointerId);
+            if (typeof button.releasePointerCapture === 'function') {
+                try {
+                    button.releasePointerCapture(event.pointerId);
+                } catch (error) {
+                    // Ignore capture release issues.
+                }
+            }
+
+            if (pointerIds.size === 0) {
+                keys[key] = false;
+                button.classList.remove('active');
+            }
+        }
+    };
+
+    button.addEventListener('pointerdown', pressKey);
+    button.addEventListener('pointerup', releaseKey);
+    button.addEventListener('pointercancel', releaseKey);
+    button.addEventListener('pointerleave', releaseKey);
+    button.addEventListener('lostpointercapture', releaseKey);
+    button.addEventListener('contextmenu', (event) => event.preventDefault());
+});
+
+canvas.addEventListener('pointerdown', (event) => {
+    event.preventDefault();
+    primeAudio();
+
+    switch (gameState) {
+        case GameStates.TITLE:
+            handleDiscreteKeyPress('Enter');
+            break;
+        case GameStates.LEVEL_TRANSITION:
+            if (pendingLevel !== null) {
+                handleDiscreteKeyPress('Enter');
+            }
+            break;
+        case GameStates.PAUSED:
+            handleDiscreteKeyPress('Escape');
+            break;
+        case GameStates.GAME_OVER:
+        case GameStates.VICTORY:
+            handleDiscreteKeyPress('Enter');
+            break;
+        default:
+            break;
+    }
+});
+
+canvas.addEventListener('contextmenu', (event) => event.preventDefault());
+
 document.addEventListener('keydown', (e) => {
     if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Space'].includes(e.code)) {
         e.preventDefault();

--- a/style.css
+++ b/style.css
@@ -5,17 +5,32 @@ body {
     justify-content: center;
     min-height: 100vh;
     margin: 0;
+    padding: 24px 16px 32px;
     background: linear-gradient(180deg, #0b1c2c 0%, #16324f 50%, #274060 100%);
     font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
     color: #f0f4ff;
     text-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+    box-sizing: border-box;
+}
+
+*, *::before, *::after {
+    box-sizing: inherit;
+}
+
+.game-shell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: min(100%, 900px);
+    gap: 16px;
 }
 
 h1 {
-    margin: 0 0 16px;
+    margin: 0;
     letter-spacing: 2px;
     text-transform: uppercase;
-    font-size: 32px;
+    font-size: clamp(24px, 5vw, 36px);
+    text-align: center;
 }
 
 canvas {
@@ -23,4 +38,110 @@ canvas {
     border-radius: 16px;
     background: transparent;
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35), inset 0 0 0 2px rgba(255, 255, 255, 0.15);
+    width: min(100%, 800px);
+    max-height: min(75vh, 600px);
+    height: auto;
+    aspect-ratio: 4 / 3;
+}
+
+.controls {
+    width: min(100%, 600px);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+    padding: 12px 16px 16px;
+    border-radius: 18px;
+    background: rgba(10, 18, 32, 0.6);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(6px);
+}
+
+.control-row {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+}
+
+.utility-controls {
+    gap: 12px;
+}
+
+.movement-controls {
+    gap: 24px;
+}
+
+.control-button {
+    flex: 1;
+    min-width: 72px;
+    padding: 14px 16px;
+    border: none;
+    border-radius: 14px;
+    background: linear-gradient(180deg, rgba(72, 121, 182, 0.9), rgba(35, 70, 120, 0.95));
+    color: #fefefe;
+    font-size: 18px;
+    letter-spacing: 1px;
+    font-weight: 600;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: transform 0.12s ease, box-shadow 0.12s ease;
+    touch-action: none;
+    user-select: none;
+}
+
+.control-button:active,
+.control-button.active {
+    transform: scale(0.95);
+    box-shadow: inset 0 6px 14px rgba(0, 0, 0, 0.45);
+}
+
+.control-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.7);
+    outline-offset: 2px;
+}
+
+@media (min-width: 900px) {
+    body {
+        padding-bottom: 48px;
+    }
+
+    .controls {
+        flex-direction: row;
+        align-items: stretch;
+        justify-content: center;
+    }
+
+    .control-row {
+        flex: 1;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .utility-controls {
+        flex: none;
+        width: auto;
+        flex-direction: row;
+    }
+
+    .movement-controls {
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .action-controls {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 540px) {
+    .control-button {
+        min-width: 64px;
+        padding: 12px;
+        font-size: 16px;
+    }
+
+    .movement-controls {
+        gap: 16px;
+    }
 }


### PR DESCRIPTION
## Summary
- wrap the game canvas in a responsive container and add on-screen controls for touch devices
- restyle the page for flexible sizing of the canvas and control clusters across breakpoints
- handle pointer interactions for touch buttons and taps so core gameplay and menu actions work without a keyboard

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cde10f602883288fc4c71f7eb4f58e