### PR TITLE
Make canvas responsive and prevent page movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,20 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Badger Bobble</h1>
-    <canvas id="gameCanvas" width="800" height="600"></canvas>
+    <div class="game-stage">
+        <h1 class="game-title">Badger Bobble</h1>
+        <canvas id="gameCanvas" width="800" height="600"></canvas>
+    </div>
+    <div class="joystick-wrapper joystick-left">
+        <div id="left-joystick" class="joystick">
+            <div class="joystick-knob"></div>
+        </div>
+    </div>
+    <div class="joystick-wrapper joystick-right">
+        <div id="right-joystick" class="joystick">
+            <div class="joystick-knob"></div>
+        </div>
+    </div>
     <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,26 +1,99 @@
+html, body {
+    height: 100%;
+}
+
 body {
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-height: 100vh;
     margin: 0;
+    overflow: hidden;
+    touch-action: none;
+    overscroll-behavior: none;
     background: linear-gradient(180deg, #0b1c2c 0%, #16324f 50%, #274060 100%);
     font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
     color: #f0f4ff;
     text-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
 }
 
-h1 {
-    margin: 0 0 16px;
+.game-stage {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.game-title {
+    position: absolute;
+    top: clamp(12px, 4vh, 32px);
+    left: 50%;
+    transform: translateX(-50%);
+    margin: 0;
     letter-spacing: 2px;
     text-transform: uppercase;
-    font-size: 32px;
+    font-size: clamp(20px, 4vw, 36px);
+    pointer-events: none;
+    z-index: 2;
 }
 
 canvas {
+    width: 100%;
+    height: 100%;
     border: none;
-    border-radius: 16px;
     background: transparent;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35), inset 0 0 0 2px rgba(255, 255, 255, 0.15);
+    display: block;
+}
+
+.joystick-wrapper {
+    position: fixed;
+    bottom: clamp(20px, 6vh, 40px);
+    width: clamp(96px, 28vw, 140px);
+    height: clamp(96px, 28vw, 140px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.85;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.joystick-left {
+    left: clamp(20px, 6vw, 40px);
+}
+
+.joystick-right {
+    right: clamp(20px, 6vw, 40px);
+}
+
+.joystick {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: rgba(11, 28, 44, 0.45);
+    border: 2px solid rgba(240, 244, 255, 0.25);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: auto;
+    touch-action: none;
+    backdrop-filter: blur(4px);
+}
+
+.joystick-knob {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), rgba(120, 180, 220, 0.65));
+    border: 2px solid rgba(255, 255, 255, 0.55);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+    transform: translate3d(0, 0, 0);
+    transition: transform 0.12s ease-out;
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .joystick-wrapper {
+        display: none;
+    }
 }


### PR DESCRIPTION
## Summary
- wrap the canvas and title in a full-screen stage and update styles so the game fills the viewport without scrolling
- resize the canvas to the window, scale rendering from fixed world dimensions, and block overscroll so touch movement no longer shifts the page
- tune joystick sizing/positioning for different screens and ensure overlays draw in the scaled coordinate system

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cde76629d0832885a3d63ffe582a54