### PR TITLE
Add fire button inside right joystick

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <div class="joystick-wrapper joystick-right">
         <div id="right-joystick" class="joystick">
             <div class="joystick-knob"></div>
+            <button id="fire-button" class="joystick-fire-button" aria-label="Shoot bubbles"></button>
         </div>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -418,6 +418,7 @@ function handlePrimaryAction() {
 function setupTouchControls() {
     const leftJoystick = document.getElementById('left-joystick');
     const rightJoystick = document.getElementById('right-joystick');
+    const fireButton = document.getElementById('fire-button');
 
     if (!leftJoystick || !rightJoystick) {
         return;
@@ -551,6 +552,50 @@ function setupTouchControls() {
             keys['KeyZ'] = false;
         }
     });
+
+    if (fireButton) {
+        const setFireActive = (isPressed) => {
+            keys['KeyZ'] = isPressed;
+            fireButton.classList.toggle('is-active', isPressed);
+        };
+
+        const pressFire = (event) => {
+            primeAudio();
+            handlePrimaryAction();
+            setFireActive(true);
+            event.preventDefault();
+            event.stopPropagation();
+        };
+
+        const releaseFire = () => {
+            setFireActive(false);
+        };
+
+        const cancelFromButton = (event) => {
+            if (event) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
+            releaseFire();
+        };
+
+        if (window.PointerEvent) {
+            fireButton.addEventListener('pointerdown', pressFire);
+            fireButton.addEventListener('pointerup', cancelFromButton);
+            fireButton.addEventListener('pointercancel', cancelFromButton);
+            fireButton.addEventListener('pointerleave', cancelFromButton);
+            window.addEventListener('pointerup', releaseFire);
+            window.addEventListener('pointercancel', releaseFire);
+        } else {
+            fireButton.addEventListener('touchstart', pressFire, { passive: false });
+            fireButton.addEventListener('touchend', cancelFromButton);
+            fireButton.addEventListener('touchcancel', cancelFromButton);
+            fireButton.addEventListener('mousedown', pressFire);
+            window.addEventListener('mouseup', releaseFire);
+            window.addEventListener('touchend', releaseFire);
+            window.addEventListener('touchcancel', releaseFire);
+        }
+    }
 }
 
 if ('ontouchstart' in window || (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0)) {

--- a/style.css
+++ b/style.css
@@ -91,6 +91,7 @@ canvas {
     pointer-events: auto;
     touch-action: none;
     backdrop-filter: blur(4px);
+    position: relative;
 }
 
 .joystick-knob {
@@ -102,6 +103,40 @@ canvas {
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
     transform: translate3d(0, 0, 0);
     transition: transform 0.12s ease-out;
+}
+
+.joystick-fire-button {
+    position: absolute;
+    bottom: 12%;
+    right: 12%;
+    width: 38%;
+    height: 38%;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(255, 130, 90, 0.85));
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+    pointer-events: auto;
+    touch-action: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.95;
+    transition: transform 0.12s ease-out, box-shadow 0.12s ease-out;
+}
+
+.joystick-fire-button:active,
+.joystick-fire-button.is-active {
+    transform: scale(0.92);
+    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
+}
+
+.joystick-fire-button::after {
+    content: '';
+    width: 40%;
+    height: 40%;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.35);
+    box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.3);
 }
 
 @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
## Summary
- add an on-screen fire button inside the right joystick overlay
- style the button to sit in the joystick and show active feedback
- hook button interactions to the existing shooting controls for touch, pointer, and mouse events

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf19c1b0f88328a54c051f6397ed44