### PR TITLE
Replace right joystick with jump and bubble buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,10 +15,9 @@
             <div class="joystick-knob"></div>
         </div>
     </div>
-    <div class="joystick-wrapper joystick-right">
-        <div id="right-joystick" class="joystick">
-            <div class="joystick-knob"></div>
-        </div>
+    <div class="action-buttons">
+        <button id="jump-button" class="action-button action-button--jump" aria-label="Jump">Jump</button>
+        <button id="fire-button" class="action-button action-button--fire" aria-label="Shoot bubbles">Bubble</button>
     </div>
     <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -75,10 +75,6 @@ canvas {
     left: clamp(20px, 6vw, 40px);
 }
 
-.joystick-right {
-    right: clamp(20px, 6vw, 40px);
-}
-
 .joystick {
     width: 100%;
     height: 100%;
@@ -91,6 +87,7 @@ canvas {
     pointer-events: auto;
     touch-action: none;
     backdrop-filter: blur(4px);
+    position: relative;
 }
 
 .joystick-knob {
@@ -104,8 +101,62 @@ canvas {
     transition: transform 0.12s ease-out;
 }
 
+
+.action-buttons {
+    position: fixed;
+    bottom: clamp(24px, 7vh, 56px);
+    right: clamp(24px, 7vw, 56px);
+    display: flex;
+    gap: clamp(14px, 4vw, 26px);
+    pointer-events: none;
+    z-index: 5;
+}
+
+.action-button {
+    pointer-events: auto;
+    touch-action: none;
+    width: clamp(70px, 20vw, 92px);
+    height: clamp(70px, 20vw, 92px);
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.92), rgba(96, 168, 216, 0.75));
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.45);
+    color: #0b1c2c;
+    font-size: clamp(0.8rem, 2.2vw, 1.1rem);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.95;
+    transition: transform 0.12s ease-out, box-shadow 0.12s ease-out;
+}
+
+.action-button:active,
+.action-button.is-active {
+    transform: scale(0.92);
+    box-shadow: 0 5px 14px rgba(0, 0, 0, 0.45);
+}
+
+.action-button--jump {
+    background: radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.95), rgba(140, 230, 170, 0.85));
+}
+
+.action-button--fire {
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.92), rgba(255, 140, 100, 0.88));
+}
+
+.action-button span {
+    pointer-events: none;
+}
+
 @media (hover: hover) and (pointer: fine) {
     .joystick-wrapper {
+        display: none;
+    }
+
+    .action-buttons {
         display: none;
     }
 }


### PR DESCRIPTION
## Summary
- replace the right joystick overlay with dedicated jump and bubble action buttons
- style the new action buttons for touch players and hide them on desktop pointers
- rework touch control wiring to drop the right joystick and hook the new buttons into jump and shoot actions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf19c1b0f88328a54c051f6397ed44